### PR TITLE
Fix missing namespace when calling get secret

### DIFF
--- a/swarm.py
+++ b/swarm.py
@@ -203,8 +203,7 @@ class Swarm(RetryingStateMachine):
                 "create",
                 "serviceaccount",
                 self.identifier,
-                "-n",
-                "default",
+                "--namespace=default",
             ]
         )
 
@@ -256,6 +255,7 @@ class Swarm(RetryingStateMachine):
                 "kubectl",
                 "get",
                 "secret",
+                "--namespace=default",
                 secret_name,
                 "-ojson",
             ]


### PR DESCRIPTION
Adds missing namespace to `kubectl get secret` Currently assisted-swarm can only be ran if the current project is set to the `default` namespace. Output using current main branch:

```
CalledProcessError: Command '['kubectl', 'get', 'secret', 'swarm-1644609261-token-x5kjd', '-ojson']' returned non-zero exit status 1.
```