### PR TITLE
Change validation image to ubi8/ubi

### DIFF
--- a/swarm.py
+++ b/swarm.py
@@ -119,7 +119,7 @@ class Swarm(RetryingStateMachine):
         ) as container_config:
             self.logging.info(f"Validating system podman lock config")
             podman_env = {"CONTAINERS_CONF": str(container_config)}
-            podman_command = self.executor.prepare_sudo_command(["podman", "run", "alpine"], env=podman_env)
+            podman_command = self.executor.prepare_sudo_command(["podman", "run", "ubi8/ubi"], env=podman_env)
 
             try:
                 self.executor.check_call(podman_command, env={**os.environ, **podman_env})


### PR DESCRIPTION
Change the image used for validating podman num_locks. Right now we are using alpine which doesn't exist on registry.redhat.io or  registry.access.redhat.com so we are relying on docker.io which could impose a rate-limit on us.